### PR TITLE
Add Data Tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,39 @@ If your regular expression captures any matches, you should provide a list of va
       puts "$quantity cucumbers bought. Price was $price"
     }
 
+You can use basic tables in your scenarios. The data from the table s made available to your step definition, via the last variable name you pass into the capture list. For example, if you had the following step in your feature:
+
+    Given I have added the following products to my shopping cart:
+      | apple  | £2.00 |
+      | orange | £3.00 |
+      | banana | £1.50 |
+
+I could write the step definition for the Given step as:
+
+    Given {^I have added the following products to my shopping cart:$} {table_data} {
+      puts "$table_data"
+    }
+
+The data in the table is provided as a list of lists, so in the above example, table data would look like:
+
+    {"apple" "£2.00"} {"orange" "£3.00"} {"banana" "£1.50"}
+
+meaning you can access each element using `lindex`, e.g.
+
+    puts [lindex [lindex $table_data 0] 0]
+    apple
+
+If your step definition captures a match in the step definition as well as has a table, the table variable will always be last, e.g.
+
+    When I buy the following items from Tesco:
+      | cabbage |
+      | potato  |
+      | onion   |
+
+and in your step definition, you might have
+
+    Given {^I buy the following items from (\w+):$} {store items} {
+      puts "I've been shopping at $store"
+      puts "The first item I bought was [lindex $items 0]"
+    }
+

--- a/features/data_tables.feature
+++ b/features/data_tables.feature
@@ -1,0 +1,25 @@
+Feature: DataTables
+
+  Scenario: Match a step with a DataTable
+    Given a file named "features/test.feature" with:
+      """
+      Feature:
+        Scenario:
+        Given passing with a DataTable:
+          | first_column | second_column |
+      """
+    And a file named "features/support/env.rb" with:
+      """
+      require 'cucumber/tcl'
+      """
+    And a file named "features/step_defintions/steps.tcl" with:
+      """
+      Given {^passing with a DataTable:$} {content} {
+        puts "raw data = [get_raw $content]"
+      }
+      """
+    When I run `cucumber`
+    Then it should pass with:
+      """
+      raw data = first_column second_column
+      """

--- a/features/data_tables.feature
+++ b/features/data_tables.feature
@@ -1,5 +1,6 @@
 Feature: DataTables
 
+  @wip
   Scenario: Match a step with a DataTable
     Given a file named "features/test.feature" with:
       """
@@ -21,5 +22,5 @@ Feature: DataTables
     When I run `cucumber`
     Then it should pass with:
       """
-      raw data = first_column second_column
+      raw data = {"first_column" "second_column"}
       """

--- a/features/data_tables.feature
+++ b/features/data_tables.feature
@@ -7,7 +7,8 @@ Feature: DataTables
       Feature:
         Scenario:
         Given passing with a DataTable:
-          | first_column | second_column |
+          | a | b |
+          | c | d |
       """
     And a file named "features/support/env.rb" with:
       """
@@ -16,11 +17,11 @@ Feature: DataTables
     And a file named "features/step_defintions/steps.tcl" with:
       """
       Given {^passing with a DataTable:$} {content} {
-        puts "raw data = [get_raw $content]"
+        puts $content
       }
       """
     When I run `cucumber`
     Then it should pass with:
       """
-      raw data = {"first_column" "second_column"}
+      {{"a" "b"} {"c" "d"}}
       """

--- a/features/data_tables.feature
+++ b/features/data_tables.feature
@@ -23,5 +23,5 @@ Feature: DataTables
     When I run `cucumber`
     Then it should pass with:
       """
-      {{"a" "b"} {"c" "d"}}
+      {{a} {b}} {{c} {d}}
       """

--- a/lib/cucumber/tcl/data_table.rb
+++ b/lib/cucumber/tcl/data_table.rb
@@ -1,0 +1,28 @@
+module Cucumber
+  module Tcl
+
+    # Wraps the Cucumber DataTable so that when passed through to tcl, its
+    # string representation is easy to parse into a tcl list.
+    class DataTable
+      def initialize(original)
+        @original = original
+      end
+
+      def to_s
+        rows = @original.raw.map { |row|
+          cells = row.map { |cell| %{"#{cell}"} }
+          to_tcl_list(cells)
+        }
+        to_tcl_list(rows)
+      end
+
+      private
+
+      def to_tcl_list(array)
+        "{" + array.join(" ") + "}"
+      end
+    end
+
+  end
+end
+

--- a/lib/cucumber/tcl/data_table.rb
+++ b/lib/cucumber/tcl/data_table.rb
@@ -5,11 +5,11 @@ module Cucumber
     # string representation is easy to parse into a tcl list.
     class DataTable
       def initialize(original)
-        @original = original
+        @raw = original.raw
       end
 
       def to_s
-        to_tcl_list(@original.raw.map { |row| to_tcl_list(row) })
+        to_tcl_list(@raw.map { |row| to_tcl_list(row) })
       end
 
       private

--- a/lib/cucumber/tcl/data_table.rb
+++ b/lib/cucumber/tcl/data_table.rb
@@ -9,10 +9,7 @@ module Cucumber
       end
 
       def to_s
-        rows = @original.raw.map { |row|
-          to_tcl_list(row)
-        }
-        to_tcl_list(rows)
+        to_tcl_list(@original.raw.map { |row| to_tcl_list(row) })
       end
 
       private

--- a/lib/cucumber/tcl/data_table.rb
+++ b/lib/cucumber/tcl/data_table.rb
@@ -10,8 +10,7 @@ module Cucumber
 
       def to_s
         rows = @original.raw.map { |row|
-          cells = row.map { |cell| %{"#{cell}"} }
-          to_tcl_list(cells)
+          to_tcl_list(row)
         }
         to_tcl_list(rows)
       end
@@ -19,7 +18,7 @@ module Cucumber
       private
 
       def to_tcl_list(array)
-        "{" + array.join(" ") + "}"
+        array.map { |element| "{" + element + "}" }.join(" ")
       end
     end
 

--- a/lib/cucumber/tcl/framework.tcl
+++ b/lib/cucumber/tcl/framework.tcl
@@ -57,7 +57,6 @@ proc step_definition_exists { step_name } {
 
 
 proc execute_step_definition { step_name {multiline_args {}} } {
-  # TODO: handle parameters in the regexp
   set res [_search_steps $step_name 1 $multiline_args]
   return $res
 

--- a/lib/cucumber/tcl/step_definitions.rb
+++ b/lib/cucumber/tcl/step_definitions.rb
@@ -1,4 +1,5 @@
 require 'tcl'
+require 'cucumber/tcl/data_table'
 
 module Cucumber
   module Tcl
@@ -31,7 +32,7 @@ module Cucumber
         end
 
         def data_table(arg)
-          @arguments << arg.raw
+          @arguments << DataTable.new(arg)
         end
 
         def to_a

--- a/lib/cucumber/tcl/step_definitions.rb
+++ b/lib/cucumber/tcl/step_definitions.rb
@@ -30,6 +30,10 @@ module Cucumber
           @arguments << arg.content
         end
 
+        def data_table(arg)
+          @arguments << arg.raw
+        end
+
         def to_a
           @arguments
         end

--- a/spec/cucumber/tcl/data_table_spec.rb
+++ b/spec/cucumber/tcl/data_table_spec.rb
@@ -1,0 +1,13 @@
+require 'cucumber/tcl/data_table'
+require 'cucumber/core/ast/data_table'
+
+module Cucumber::Tcl
+  describe DataTable do
+    it "#to_s converts to Tcl list of lists" do
+      raw = [["a", "b"], ["c", "d"]]
+      original = Cucumber::Core::Ast::DataTable.new(raw, Cucumber::Core::Ast::Location.new(__FILE__, 8))
+      table = DataTable.new(original)
+      expect(table.to_s).to eq '{{"a" "b"} {"c" "d"}}'
+    end
+  end
+end

--- a/spec/cucumber/tcl/data_table_spec.rb
+++ b/spec/cucumber/tcl/data_table_spec.rb
@@ -7,7 +7,7 @@ module Cucumber::Tcl
       raw = [["a", "b"], ["c", "d"]]
       original = Cucumber::Core::Ast::DataTable.new(raw, Cucumber::Core::Ast::Location.new(__FILE__, 8))
       table = DataTable.new(original)
-      expect(table.to_s).to eq '{{"a" "b"} {"c" "d"}}'
+      expect(table.to_s).to eq '{{a} {b}} {{c} {d}}'
     end
   end
 end


### PR DESCRIPTION
I've added a failing feature for this one - I think we'll need a few more features, but I've kept it simple for now - just a single row. I've also guessed at a tcl proc name - I suspect that will have to change once I've thought about it a bit more.

The other types that I think we'll definitely need are:

    | heading_1 | heading_2 |
    | data 1    | data 2    |

    | heading_1 | data 1 |
    | heading_2 | data 2 |

and, of course, something with multiple values in:

    | heading_1 | heading_2 |
    | row_1 1   | row_1 2   |
    | row_2 1   | row_2 2   |
    | row_3 1   | row_3 2   |
