### PR TITLE
Define a failing step where there is no steps file

### DIFF
--- a/features/define_a_step.feature
+++ b/features/define_a_step.feature
@@ -46,3 +46,28 @@ Feature: Define a step
       Hello 123
       """
 
+  @wip
+  Scenario: Define a feature with no steps file
+    Given a file named "features/test.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given passing
+      """
+    And a file named "features/support/env.rb" with:
+      """
+      require 'cucumber/tcl'
+      """
+    When I run `cucumber`
+    Then it should pass with:
+      """
+      Feature: 
+
+        Scenario: 
+          Given pending
+            TODO: Step not yet implemented (Cucumber::Core::Test::Result::Pending)
+            features/test.feature:3:in `Given pending'
+
+      1 scenario (1 pending)
+      1 step (1 pending)
+      """

--- a/features/define_a_step.feature
+++ b/features/define_a_step.feature
@@ -108,7 +108,7 @@ Feature: Define a step
       1 step (1 failed)
       """
 
-  Scenario: Define a failing step
+  Scenario: Define a step that calls a failing proc
     Given a file named "features/test.feature" with:
       """
       Feature:

--- a/features/define_a_step.feature
+++ b/features/define_a_step.feature
@@ -46,7 +46,6 @@ Feature: Define a step
       Hello 123
       """
 
-  @wip
   Scenario: Define a feature with no steps file
     Given a file named "features/test.feature" with:
       """
@@ -69,3 +68,44 @@ Feature: Define a step
       1 scenario (1 undefined)
       1 step (1 undefined)
       """
+
+  @wip
+  Scenario: Define a failing step
+    Given a file named "features/test.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given failing
+      """
+    And a file named "features/support/env.rb" with:
+      """
+      require 'cucumber/tcl'
+      """
+    And a file named "features/step_defintions/steps.tcl" with:
+      """
+      Given {^failing$} {
+        error "Failing Step"
+      }
+      """
+    When I run `cucumber`
+    Then it should fail with:
+      """
+      Feature: 
+      
+        Scenario:       # features/test.feature:2
+          Given failing # features/test.feature:3
+            Failing Step
+                while executing
+            "error "Failing Step""
+                ("eval" body line 2)
+                invoked from within
+            "eval $existing_step_body" (Tcl::Error)
+            features/test.feature:3:in `Given failing'
+      
+      Failing Scenarios:
+      cucumber features/test.feature:2 # Scenario: 
+      
+      1 scenario (1 failed)
+      1 step (1 failed)
+      """
+

--- a/features/define_a_step.feature
+++ b/features/define_a_step.feature
@@ -52,7 +52,7 @@ Feature: Define a step
       """
       Feature:
         Scenario:
-          Given passing
+          Given undefined
       """
     And a file named "features/support/env.rb" with:
       """
@@ -63,11 +63,9 @@ Feature: Define a step
       """
       Feature: 
 
-        Scenario: 
-          Given pending
-            TODO: Step not yet implemented (Cucumber::Core::Test::Result::Pending)
-            features/test.feature:3:in `Given pending'
+        Scenario:         # features/test.feature:2
+          Given undefined # features/test.feature:3
 
-      1 scenario (1 pending)
-      1 step (1 pending)
+      1 scenario (1 undefined)
+      1 step (1 undefined)
       """

--- a/features/define_a_step.feature
+++ b/features/define_a_step.feature
@@ -69,7 +69,6 @@ Feature: Define a step
       1 step (1 undefined)
       """
 
-  @wip
   Scenario: Define a failing step
     Given a file named "features/test.feature" with:
       """
@@ -97,6 +96,51 @@ Feature: Define a step
             Failing Step
                 while executing
             "error "Failing Step""
+                ("eval" body line 2)
+                invoked from within
+            "eval $existing_step_body" (Tcl::Error)
+            features/test.feature:3:in `Given failing'
+      
+      Failing Scenarios:
+      cucumber features/test.feature:2 # Scenario: 
+      
+      1 scenario (1 failed)
+      1 step (1 failed)
+      """
+
+  Scenario: Define a failing step
+    Given a file named "features/test.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given failing
+      """
+    And a file named "features/support/env.rb" with:
+      """
+      require 'cucumber/tcl'
+      """
+    And a file named "features/step_defintions/steps.tcl" with:
+      """
+      Given {^failing$} {
+        failing_proc
+      }
+      proc failing_proc {} {
+        error "Failing Step"
+      }
+      """
+    When I run `cucumber`
+    Then it should fail with:
+      """
+      Feature: 
+      
+        Scenario:       # features/test.feature:2
+          Given failing # features/test.feature:3
+            Failing Step
+                while executing
+            "error "Failing Step""
+                (procedure "failing_proc" line 2)
+                invoked from within
+            "failing_proc"
                 ("eval" body line 2)
                 invoked from within
             "eval $existing_step_body" (Tcl::Error)

--- a/lib/cucumber/tcl/framework.tcl
+++ b/lib/cucumber/tcl/framework.tcl
@@ -107,7 +107,7 @@ proc ::cucumber::source_steps args {
 
   if {$TEST ne 1} {
     #TODO let that path be configurable from cucumber-ruby
-    foreach x [glob features/**/*.tcl] {
+    foreach x [glob -nocomplain features/**/*.tcl] {
         source $x
     }
   }


### PR DESCRIPTION
I've been meaning to fix this one for a couple of weeks. First scenario is where there is no steps file, which currently blows up in the tcl. We should also add scenarios for undefined steps, etc. But one at a time...