### PR TITLE
Fix file sourcing order, source files in global namespace

### DIFF
--- a/features/file_sourcing.feature
+++ b/features/file_sourcing.feature
@@ -1,5 +1,71 @@
 Feature: Sourcing tcl files
 
+  Scenario: Source files in the appropriate order (no command line options)
+    Given a file named "features/test.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given testing file sourcing
+      """
+    And a file named "features/step_definitions/steps.tcl" with:
+      """
+      puts "Sourced step_definitions/steps.tcl"
+      """
+    And a file named "features/support/db.tcl" with:
+      """
+      puts "Sourced support/db.tcl"
+      """
+    And a file named "features/support/env.rb" with:
+      """
+      require 'cucumber/tcl'
+      """
+    And a file named "features/support/env.tcl" with:
+      """
+      puts "Sourced support/env.tcl"
+      """
+    When I run `cucumber`
+    Then it should pass with:
+      """
+      Sourced support/env.tcl
+      Sourced support/db.tcl
+      Sourced step_definitions/steps.tcl
+      """
+
+  Scenario: Source files in the appropriate order (with command line options)
+    Given a file named "myfeatures/group one/test.feature" with:
+      """
+      Feature:
+        Scenario:
+          Given testing file sourcing
+      """
+    And a file named "myfeatures/step definitions/steps.tcl" with:
+      """
+      puts "Sourced step definitions/steps.tcl"
+      """
+    And a file named "myfeatures/support/db.tcl" with:
+      """
+      puts "Sourced support/db.tcl"
+      """
+    And a file named "myfeatures/support/debug.tcl" with:
+      """
+      puts "Sourced support/debug.tcl"
+      """
+    And a file named "myfeatures/support/env.rb" with:
+      """
+      require 'cucumber/tcl'
+      """
+    And a file named "myfeatures/support/env.tcl" with:
+      """
+      puts "Sourced support/env.tcl"
+      """
+    When I run `cucumber 'myfeatures/group one/test.feature' --require myfeatures --exclude 'debug.*'`
+    Then it should pass with:
+      """
+      Sourced support/env.tcl
+      Sourced support/db.tcl
+      Sourced step definitions/steps.tcl
+      """
+
   Scenario: Display stack trace when there is an error in a sourced file
     Given a file named "features/test.feature" with:
       """
@@ -23,7 +89,10 @@ Feature: Sourcing tcl files
       "error "Fail sourcing""
           (file "features/support/helper.tcl" line 1)
           invoked from within
-      "source $x" (Tcl::Error)
+      "source features/support/helper.tcl"
+          ("uplevel" body line 1)
+          invoked from within
+      "uplevel #0 [list source $file]" (Tcl::Error)
       """
 
   Scenario: Display stack trace with multiple levels
@@ -56,5 +125,8 @@ Feature: Sourcing tcl files
       "test_proc"
           (file "features/support/helper.tcl" line 5)
           invoked from within
-      "source $x" (Tcl::Error)
+      "source features/support/helper.tcl"
+          ("uplevel" body line 1)
+          invoked from within
+      "uplevel #0 [list source $file]" (Tcl::Error)
       """

--- a/lib/cucumber/tcl.rb
+++ b/lib/cucumber/tcl.rb
@@ -14,7 +14,7 @@ module Cucumber
 
     def self.install(cucumber_config)
       create_step_definitions = lambda {
-        StepDefinitions.new(Framework.new)
+        StepDefinitions.new(Framework.new(cucumber_config))
       }
       cucumber_config.filters << ActivateSteps.new(create_step_definitions)
     end

--- a/lib/cucumber/tcl/framework.rb
+++ b/lib/cucumber/tcl/framework.rb
@@ -3,8 +3,12 @@ module Cucumber
     class Framework
       TCL_FRAMEWORK_PATH = File.dirname(__FILE__) + '/framework.tcl'
 
-      def initialize(path = TCL_FRAMEWORK_PATH)
+      def initialize(cucumber_config = nil, path = TCL_FRAMEWORK_PATH)
         @tcl = ::Tcl::Interp.load_from_file(path)
+
+        all_files_to_load = cucumber_config.nil? ? [] : cucumber_config.all_files_to_load
+        all_files_to_load.collect! {|f| f.gsub(/([\\\s{}])/, '\\\\\1')}
+        @tcl.proc('source_files').call(all_files_to_load.join(' '))
       end
 
       def step_definition_exists?(step_name)

--- a/lib/cucumber/tcl/framework.tcl
+++ b/lib/cucumber/tcl/framework.tcl
@@ -103,7 +103,7 @@ proc ::cucumber::_search_steps {step_name {execute 0} {multiline_args {}}} {
   return 0
 }
 
-# Sort a list of files such that: */source/env.{ext} < */source/{file} < */{file}
+# Sort a list of files such that: */support/env.{ext} < */support/{file} < */{file}
 proc ::cucumber::_sort_by_source_priority {a b} {
 
   if {[string equal [lindex [file split $a] end-1] "support"]} {

--- a/lib/cucumber/tcl/test/test_framework.tcl
+++ b/lib/cucumber/tcl/test/test_framework.tcl
@@ -122,6 +122,56 @@ test Then-1 {calling Then adds a new entry to the STEPS list} {
 
 
 #
+# Test _sort_by_source_priority procedure
+#
+test _sort_by_source_priority-1 {_sort_by_source_priority prioritises support/env.{ext} over other support/ files} {
+  -body {
+    set sort [::cucumber::_sort_by_source_priority "test/support/abc.ext" "test/support/env.ext"]
+    # only interested if sort is +ve, 0 or -ve; convert to 1, 0 or -1
+    expr { $sort == 0 ? 0 : $sort / abs($sort) }
+  }
+  -result 1
+}
+
+test _sort_by_source_priority-2 {_sort_by_source_priority prioritises support/env.{ext} over other support/ files} {
+  -body {
+    set sort [::cucumber::_sort_by_source_priority "test/support/env.ext" "test/support/abc.ext"]
+    # only interested if sort is +ve, 0 or -ve; convert to 1, 0 or -1
+    expr { $sort == 0 ? 0 : $sort / abs($sort) }
+  }
+  -result -1
+}
+
+test _sort_by_source_priority-3 {_sort_by_source_priority prioritises support/ files over other files} {
+  -body {
+    set sort [::cucumber::_sort_by_source_priority "test/features/abc.ext" "test/support/abc.ext"]
+    # only interested if sort is +ve, 0 or -ve; convert to 1, 0 or -1
+    expr { $sort == 0 ? 0 : $sort / abs($sort) }
+  }
+  -result 1
+}
+
+test _sort_by_source_priority-4 {_sort_by_source_priority prioritises support/ files over other files} {
+  -body {
+    set sort [::cucumber::_sort_by_source_priority "test/support/abc.ext" "test/features/abc.ext"]
+    # only interested if sort is +ve, 0 or -ve; convert to 1, 0 or -1
+    expr { $sort == 0 ? 0 : $sort / abs($sort) }
+  }
+  -result -1
+}
+
+test _sort_by_source_priority-5 {_sort_by_source_priority prioritises non support/ files equally} {
+  -body {
+    set sort [::cucumber::_sort_by_source_priority "test/lib/abc.ext" "test/etc/abc.ext"]
+    # only interested if sort is +ve, 0 or -ve; convert to 1, 0 or -1
+    expr { $sort == 0 ? 0 : $sort / abs($sort) }
+  }
+  -result 0
+}
+
+
+
+#
 # Test _search_steps procedure
 #
 test _search_steps-1 {_search_steps returns 0 if there are no existing steps} {

--- a/spec/cucumber/tcl/fixtures/everything_ok.tcl
+++ b/spec/cucumber/tcl/fixtures/everything_ok.tcl
@@ -1,3 +1,6 @@
+proc source_files { files } {
+}
+
 proc execute_step_definition { step_name } {
 }
 

--- a/spec/cucumber/tcl/step_definitions_spec.rb
+++ b/spec/cucumber/tcl/step_definitions_spec.rb
@@ -12,7 +12,7 @@ module Cucumber::Tcl
 
     it "can activate a passing tcl step" do
       path = File.dirname(__FILE__) + '/fixtures/everything_ok.tcl'
-      tcl_framework = Framework.new(path)
+      tcl_framework = Framework.new(nil, path)
       step_definitions = StepDefinitions.new(tcl_framework)
       expect(step_definitions.attempt_to_activate(test_step).location).to eq location
     end


### PR DESCRIPTION
* Using Cucumber::Cli::Configuration.all_files_to_load to drive sourcing of Tcl files (rather than just scouring features/* for Tcl files).
* Files now sourced in order: */support/env.tcl before */support/_filename_.tcl before */_filename_.tcl
* Files are sourced into the global namespace (rather than the ::cucumber namespace).