### PR TITLE
Avoid starting a new TCL interpreter for each scenario

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ To become a release manager, create a pull request adding your name to the list 
 Current release managers:
   * [Matt Wynne](https://rubygems.org/profiles/mattwynne)
   * [Jonathan Owers](https://rubygems.org/profiles/jowers)
+  * [Shaun Bristow](https://rubygems.org/profiles/ahhbristow)
 
 To grant release privilege, issue the following command:
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@ and in your step definition, you might have
 Resetting state between scenarios
 ---------------------------------
 
-Depending on how your test and/or application code is structured, there may be a chance of data persisting between scenarios, which could result in tests that pass or fail unexpectedly.  To eliminiate the risk of this, Cucumber TCL will start a new TCL interpreter between every scenario, meaning that the env.tcl file is loaded each time.  Whilst this will remove the data leakage risk, it may also cause your scenarios to run slowly if there is a lot of setup required for a scenario to run (eg, setting up fixture data, building a database or loading large amounts of data into memory).  To override the default behaviour of starting up a new interpreter, an environment variable can be passed into the 'cucumber' command disabling it:
+Depending on how your test and/or application code is structured, there may be a chance of data persisting between scenarios, which could result in tests that pass or fail unexpectedly.  To eliminiate the risk of this, Cucumber TCL will start a new TCL interpreter between every scenario by creating a new instance of the 'framework' object, meaning that the env.tcl file is loaded each time.  Whilst this will remove the data leakage risk, it may also cause your scenarios to run slowly if there is a lot of setup required for a scenario to run (eg, setting up fixture data, building a database or loading large amounts of data into memory).  To override the default behaviour of starting up a new interpreter, an environment variable can be passed into the 'cucumber' command enabling the sharing of the TCL interpreter via the 'framework' object:
 
-    cucumber NEW_INTERPRETER=0
+    cucumber SHARE_FRAMEWORK=1
 
 It's also possible to make the default behaviour of starting up a new interpreter explicit:
 
-    cucumber NEW_INTERPRETER=1
+    cucumber SHARE_FRAMEWORK=0
 
-If you are wrapping Cucumber around poorly understood legacy TCL code, you may wish to disable starting up a new interpreter during development in the interests of running tests quickly, but retain the default behaviour in your CI build to remove the risk of data leakage if you think there is a chance of this.
+If you are wrapping Cucumber around poorly understood legacy TCL code, you may wish to enable sharing of the framework object (and thus avoid starting a new TCL interpreter) during development in the interests of running tests quickly, but retain the default behaviour in your CI build to remove the risk of data leakage if you think there is a chance of this.

--- a/README.md
+++ b/README.md
@@ -88,3 +88,15 @@ and in your step definition, you might have
       puts "The first item I bought was [lindex $items 0]"
     }
 
+Resetting state between scenarios
+---------------------------------
+
+Depending on how your test and/or application code is structured, there may be a chance of data persisting between scenarios, which could result in tests that pass or fail unexpectedly.  To eliminiate the risk of this, Cucumber TCL will start a new TCL interpreter between every scenario, meaning that the env.tcl file is loaded each time.  Whilst this will remove the data leakage risk, it may also cause your scenarios to run slowly if there is a lot of setup required for a scenario to run (eg, setting up fixture data, building a database or loading large amounts of data into memory).  To override the default behaviour of starting up a new interpreter, an environment variable can be passed into the 'cucumber' command disabling it:
+
+    cucumber NEW_INTERPRETER=0
+
+It's also possible to make the default behaviour of starting up a new interpreter explicit:
+
+    cucumber NEW_INTERPRETER=1
+
+If you are wrapping Cucumber around poorly understood legacy TCL code, you may wish to disable starting up a new interpreter during development in the interests of running tests quickly, but retain the default behaviour in your CI build to remove the risk of data leakage if you think there is a chance of this.

--- a/cucumber-tcl.gemspec
+++ b/cucumber-tcl.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9.3"
 
   s.add_dependency 'ruby-tcl', '~> 0.1.1'
-  s.add_dependency 'cucumber', '~> 2.0.0.rc.4'
+  s.add_dependency 'cucumber', '~> 2.0.0'
 
   s.add_development_dependency 'rspec', '~> 3.2'
   s.add_development_dependency 'aruba', '~> 0.6'

--- a/features/file_sourcing.feature
+++ b/features/file_sourcing.feature
@@ -7,9 +7,13 @@ Feature: Sourcing tcl files
         Scenario:
           Given testing file sourcing
       """
-    And a file named "features/step_definitions/steps.tcl" with:
+    And a file named "features/step_definitions/steps_a.tcl" with:
       """
-      puts "Sourced step_definitions/steps.tcl"
+      puts "Sourced step_definitions/steps_a.tcl"
+      """
+    And a file named "features/step_definitions/steps_b.tcl" with:
+      """
+      puts "Sourced step_definitions/steps_b.tcl"
       """
     And a file named "features/support/db.tcl" with:
       """
@@ -28,7 +32,8 @@ Feature: Sourcing tcl files
       """
       Sourced support/env.tcl
       Sourced support/db.tcl
-      Sourced step_definitions/steps.tcl
+      Sourced step_definitions/steps_a.tcl
+      Sourced step_definitions/steps_b.tcl
       """
 
   Scenario: Source files in the appropriate order (with command line options)

--- a/features/reset_state.feature
+++ b/features/reset_state.feature
@@ -38,22 +38,22 @@ Feature: Reset state
       require 'cucumber/tcl'
       """
 	
-  Scenario: State is not reset when running 'cucumber' with no options
+  Scenario: State reset when running 'cucumber' with no options
     When I run `cucumber`
     Then it should fail with:
        """
        can't read "::g": no such variable
        """
 
-  Scenario: State reset when running 'cucumber' with the new interpreter flag on
-    When I run `cucumber NEW_INTERPRETER=1`
+  Scenario: State reset when running 'cucumber' with a new framework object for each scenario
+    When I run `cucumber SHARE_FRAMEWORK=0`
     Then it should fail with:
        """
        can't read "::g": no such variable
        """
 
-  Scenario: State not reset when running 'cucumber' with new interpreter flag off
-    When I run `cucumber NEW_INTERPRETER=0`
+  Scenario: State not reset when running 'cucumber' and sharing framework object
+    When I run `cucumber SHARE_FRAMEWORK=1`
     Then it should pass with:
       """
       2 scenarios (2 passed)

--- a/features/reset_state.feature
+++ b/features/reset_state.feature
@@ -3,7 +3,14 @@ Feature: Reset state
   In order to keep state from leaking between scenarios, by default,
   we create a new Tcl interpreter for each test case.
 
-  Scenario: Set a global variable in one scenario and access it in another
+  In order to prevent long setup time before each scenario
+  we can optionally avoid starting a new TCL interpreter
+
+  Rules:
+    -- The state is maintained between scenarios if an environment variable is passed into Cucumber
+    -- Otherwise a new TCL interpreter is started and state is reset on each scenario
+
+  Background:
     Given a file named "features/test.feature" with:
       """
       Feature:
@@ -30,8 +37,39 @@ Feature: Reset state
       """
       require 'cucumber/tcl'
       """
+	
+  Scenario: State is not reset when running 'cucumber' with no options
     When I run `cucumber`
-    Then it should fail with:
-      """
-      can't read "::g": no such variable
-      """
+    Then the exit status should be 1
+
+  Scenario: State reset when running 'cucumber' with the new interpreter flag on
+    When I run `cucumber NEW_INTERPRETER=1`
+    Then the exit status should be 1
+
+  Scenario: State not reset when running 'cucumber' with new interpreter flag OF
+    When I run `cucumber NEW_INTERPRETER=0`
+    Then the exit status should be 0
+
+    # TODO (sbristow): This step fails because the actual Cucumber output
+    # does not match exactly the expected output.  It looks like
+    # the "puts" command inside the step definition is writing
+    # to the output buffer, which somehow ends up with output
+    # printed out of order.  The value of '$value' is printed
+    # above the Scenario rather than the step it's called in.
+    # This is difficult to debug and I've not found the problem as of yet.
+    #Then it should pass with:
+    #  """
+    #  Feature: 
+
+    #    Scenario:                          # features/test.feature:2
+    #      Given I set a global variable    # features/test.feature:3
+    #  value
+    #      When I print the global variable # features/test.feature:4
+
+    #    Scenario:                          # features/test.feature:6
+    #  value
+    #      When I print the global variable # features/test.feature:7
+
+    #  2 scenarios (2 passed)
+    #  3 steps (3 passed)
+    #  """

--- a/features/reset_state.feature
+++ b/features/reset_state.feature
@@ -40,15 +40,25 @@ Feature: Reset state
 	
   Scenario: State is not reset when running 'cucumber' with no options
     When I run `cucumber`
-    Then the exit status should be 1
+    Then it should fail with:
+       """
+       can't read "::g": no such variable
+       """
 
   Scenario: State reset when running 'cucumber' with the new interpreter flag on
     When I run `cucumber NEW_INTERPRETER=1`
-    Then the exit status should be 1
+    Then it should fail with:
+       """
+       can't read "::g": no such variable
+       """
 
-  Scenario: State not reset when running 'cucumber' with new interpreter flag OF
+  Scenario: State not reset when running 'cucumber' with new interpreter flag off
     When I run `cucumber NEW_INTERPRETER=0`
-    Then the exit status should be 0
+    Then it should pass with:
+      """
+      2 scenarios (2 passed)
+      3 steps (3 passed)
+      """
 
     # TODO (sbristow): This step fails because the actual Cucumber output
     # does not match exactly the expected output.  It looks like

--- a/features/reset_state.feature
+++ b/features/reset_state.feature
@@ -59,27 +59,3 @@ Feature: Reset state
       2 scenarios (2 passed)
       3 steps (3 passed)
       """
-
-    # TODO (sbristow): This step fails because the actual Cucumber output
-    # does not match exactly the expected output.  It looks like
-    # the "puts" command inside the step definition is writing
-    # to the output buffer, which somehow ends up with output
-    # printed out of order.  The value of '$value' is printed
-    # above the Scenario rather than the step it's called in.
-    # This is difficult to debug and I've not found the problem as of yet.
-    #Then it should pass with:
-    #  """
-    #  Feature: 
-
-    #    Scenario:                          # features/test.feature:2
-    #      Given I set a global variable    # features/test.feature:3
-    #  value
-    #      When I print the global variable # features/test.feature:4
-
-    #    Scenario:                          # features/test.feature:6
-    #  value
-    #      When I print the global variable # features/test.feature:7
-
-    #  2 scenarios (2 passed)
-    #  3 steps (3 passed)
-    #  """

--- a/lib/cucumber/tcl.rb
+++ b/lib/cucumber/tcl.rb
@@ -13,9 +13,27 @@ module Cucumber
   module Tcl
 
     def self.install(cucumber_config)
-      create_step_definitions = lambda {
-        StepDefinitions.new(Framework.new(cucumber_config))
-      }
+      # Unless configured off, we should start up a new
+      # framework for each scenarion, which results
+      # in a new TCL interpreter.  This can be used
+      # to check that there is no data leakage between
+      # scenarios when testing poorly understood code
+      if ENV["NEW_INTERPRETER"].nil?
+          new_interpreter = 1
+      else 
+          new_interpreter = ENV['NEW_INTERPRETER'].to_i
+      end
+
+      if new_interpreter == 1
+          create_step_definitions = lambda {
+            StepDefinitions.new(Framework.new(cucumber_config))
+          }
+      else
+          framework = Framework.new(cucumber_config)
+          create_step_definitions = lambda {
+            StepDefinitions.new(framework)
+          }
+      end
       cucumber_config.filters << ActivateSteps.new(create_step_definitions)
     end
 

--- a/lib/cucumber/tcl.rb
+++ b/lib/cucumber/tcl.rb
@@ -14,17 +14,13 @@ module Cucumber
 
     def self.install(cucumber_config)
       # Unless configured off, we should start up a new
-      # framework for each scenarion, which results
+      # framework for each scenario, which results
       # in a new TCL interpreter.  This can be used
       # to check that there is no data leakage between
       # scenarios when testing poorly understood code
-      if ENV["NEW_INTERPRETER"].nil?
-          new_interpreter = 1
-      else 
-          new_interpreter = ENV['NEW_INTERPRETER'].to_i
-      end
+      share_framework = (ENV['SHARE_FRAMEWORK'] == '1')
 
-      if new_interpreter == 1
+      if !share_framework
           create_step_definitions = lambda {
             StepDefinitions.new(Framework.new(cucumber_config))
           }

--- a/lib/cucumber/tcl/framework.tcl
+++ b/lib/cucumber/tcl/framework.tcl
@@ -133,7 +133,7 @@ proc ::cucumber::source_files {files} {
   variable TEST
 
   if {$TEST ne 1} {
-    foreach file [lsort -unique -command _sort_by_source_priority $files] {
+    foreach file [lsort -command _sort_by_source_priority $files] {
       if {[string equal [file extension $file] ".tcl"]} {
         if {[catch {
           uplevel #0 [list source $file]


### PR DESCRIPTION
I've added support to pass in an environment variable called NEW_INTERPRETER when running Cucumber TCL.  This changes Cucumber TCL to not start a new TCL interpreter for each scenario, which drastically improves the speed of our tests by not having to source env.tcl each time (which may do a lot of initialisation work).  By passing NEW_INTERPRETER=1 into the Cucumber command, you can force a new interpreter.

This may be useful if you believe there is data leakage between scenarios due to TCL packages loaded as part of the test run retaining global or namespace variables, which could be a problem for poorly understood legacy code.

NEW_INTERPRETER defaults to 0.